### PR TITLE
enable searching for a regex

### DIFF
--- a/OpenAlprWebhookProcessor/ClientApp/src/app/plates/plate.service.ts
+++ b/OpenAlprWebhookProcessor/ClientApp/src/app/plates/plate.service.ts
@@ -31,6 +31,7 @@ export class PlateRequest {
     endSearchOn: Date;
     strictMatch: boolean;
     filterIgnoredPlates: boolean;
+    regexSearchEnabled: boolean
     pageNumber: number;
     pageSize: number;
 }

--- a/OpenAlprWebhookProcessor/ClientApp/src/app/plates/plates.component.html
+++ b/OpenAlprWebhookProcessor/ClientApp/src/app/plates/plates.component.html
@@ -64,31 +64,46 @@
           </mat-date-range-input>
           <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
           <mat-date-range-picker #picker></mat-date-range-picker>
-          <mat-error *ngIf="range.controls.start.hasError('matStartDateInvalid')">Invalid start date</mat-error>
-          <mat-error *ngIf="range.controls.end.hasError('matEndDateInvalid')">Invalid end date</mat-error>
         </mat-form-field>
         <mat-form-field appearance="fill">
           <mat-label>Plate Number</mat-label>
-          <input matInput [(ngModel)]="filterPlateNumber" (keyup.enter)="searchPlates()" placeholder="LRN2DRV">
+          <input matInput
+            [(ngModel)]="filterPlateNumber"
+            (keyup.enter)="searchPlates()"
+            (input)="validateSearchPlateNumber()"
+            placeholder="LRN2DRV" />
         </mat-form-field>
-        <mat-divider></mat-divider>
+        <mat-error *ngIf="!filterPlateNumberIsValid && regexSearchEnabled">Invalid regex pattern</mat-error>
+        <mat-error *ngIf="!filterPlateNumberIsValid && !regexSearchEnabled">Invalid search term</mat-error>
         <div style="padding-top:10px;">
           <ul class="options-list">
             <li>
-              <mat-checkbox color="primary" [(ngModel)]="filterIgnoredPlates">Include Ignored Plates</mat-checkbox>
+              <mat-checkbox 
+                color="primary"
+                [(ngModel)]="filterIgnoredPlates"
+                [disabled]="!filterIgnoredPlatesEnabled">Include Ignored Plates</mat-checkbox>
             </li>
             <li>
-              <mat-checkbox color="primary" [(ngModel)]="regexSearchEnabled">Regex Search</mat-checkbox>
+              <mat-checkbox
+                color="primary"
+                (change)="regexSearchToggled()"
+                [(ngModel)]="regexSearchEnabled">Regex Search</mat-checkbox>
             </li>
             <li>
-              <mat-checkbox color="primary" [(ngModel)]="filterStrictMatch">Lenient Matches</mat-checkbox>
+              <mat-checkbox
+                color="primary"
+                [(ngModel)]="filterStrictMatch"
+                [disabled]="!filterStrictMatchEnabled">Lenient Matches</mat-checkbox>
             </li>
           </ul>
         </div>
 
       </mat-card-content>
       <mat-card-actions>
-        <button mat-raised-button color="primary" (click)="searchPlates()">Apply</button>
+        <button mat-raised-button
+          color="primary"
+          [disabled]="!this.filterPlateNumberIsValid"
+          (click)="searchPlates()">Apply</button>
         <button mat-raised-button color="warn" (click)="clearFilters()">Clear</button>
       </mat-card-actions>
     </mat-card>

--- a/OpenAlprWebhookProcessor/ClientApp/src/app/plates/plates.component.html
+++ b/OpenAlprWebhookProcessor/ClientApp/src/app/plates/plates.component.html
@@ -78,6 +78,9 @@
               <mat-checkbox color="primary" [(ngModel)]="filterIgnoredPlates">Include Ignored Plates</mat-checkbox>
             </li>
             <li>
+              <mat-checkbox color="primary" [(ngModel)]="regexSearchEnabled">Regex Search</mat-checkbox>
+            </li>
+            <li>
               <mat-checkbox color="primary" [(ngModel)]="filterStrictMatch">Lenient Matches</mat-checkbox>
             </li>
           </ul>

--- a/OpenAlprWebhookProcessor/ClientApp/src/app/plates/plates.component.ts
+++ b/OpenAlprWebhookProcessor/ClientApp/src/app/plates/plates.component.ts
@@ -61,6 +61,7 @@ export class PlatesComponent implements OnInit, OnDestroy, AfterViewInit {
   public filterEndOn: Date;
   public filterStrictMatch: boolean;
   public filterIgnoredPlates: boolean;
+  public regexSearchEnabled: boolean;
 
   public addingToIgnoreList: boolean;
 
@@ -132,6 +133,7 @@ export class PlatesComponent implements OnInit, OnDestroy, AfterViewInit {
     request.plateNumber = this.filterPlateNumber;
     request.strictMatch = this.filterStrictMatch;
     request.filterIgnoredPlates = this.filterIgnoredPlates;
+    request.regexSearchEnabled = this.regexSearchEnabled;
 
     this.plateService.searchPlates(request).subscribe(result => {
       this.totalNumberOfPlates = result.totalCount;
@@ -145,6 +147,7 @@ export class PlatesComponent implements OnInit, OnDestroy, AfterViewInit {
     this.filterPlateNumber = '';
     this.filterStrictMatch = false;
     this.filterIgnoredPlates = false;
+    this.regexSearchEnabled = false;
 
     this.searchPlates();
   }

--- a/OpenAlprWebhookProcessor/ClientApp/src/app/plates/plates.component.ts
+++ b/OpenAlprWebhookProcessor/ClientApp/src/app/plates/plates.component.ts
@@ -1,6 +1,6 @@
 import { animate, state, style, transition, trigger } from '@angular/animations';
 import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { FormControl, FormGroup } from '@angular/forms';
+import { FormControl, FormGroup, FormGroupDirective, NgForm } from '@angular/forms';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
 import { Ignore } from '@app/settings/ignores/ignore/ignore';
@@ -12,6 +12,7 @@ import { Lightbox } from 'ngx-lightbox';
 import { Subscription } from 'rxjs';
 import { Plate } from './plate';
 import { PlateRequest, PlateService } from './plate.service';
+import { ErrorStateMatcher } from '@angular/material/core';
 
 @Component({
   selector: 'app-plates',
@@ -57,10 +58,13 @@ export class PlatesComponent implements OnInit, OnDestroy, AfterViewInit {
   public totalNumberOfPlates: number;
 
   public filterPlateNumber: string;
+  public filterPlateNumberIsValid: boolean = true;
   public filterStartOn: Date;
   public filterEndOn: Date;
   public filterStrictMatch: boolean;
+  public filterStrictMatchEnabled: boolean = true;
   public filterIgnoredPlates: boolean;
+  public filterIgnoredPlatesEnabled: boolean = true;
   public regexSearchEnabled: boolean;
 
   public addingToIgnoreList: boolean;
@@ -98,7 +102,7 @@ export class PlatesComponent implements OnInit, OnDestroy, AfterViewInit {
 
   public subscribeForUpdates() {
     this.subscriptions.add(this.signalRHub.licensePlateReceived.subscribe(result => {
-      this.searchPlates();
+        this.searchPlates();
     }));
   }
 
@@ -121,6 +125,10 @@ export class PlatesComponent implements OnInit, OnDestroy, AfterViewInit {
 
   public searchPlates(plateNumber: string = '') {
     var request = new PlateRequest();
+
+    if (!this.filterPlateNumberIsValid) {
+      return;
+    }
 
     if (plateNumber !== '') {
       this.filterPlateNumber = plateNumber;
@@ -145,8 +153,11 @@ export class PlatesComponent implements OnInit, OnDestroy, AfterViewInit {
     this.filterEndOn = null;
     this.filterStartOn = null;
     this.filterPlateNumber = '';
+    this.filterPlateNumberIsValid = true;
     this.filterStrictMatch = false;
+    this.filterStrictMatchEnabled = true;
     this.filterIgnoredPlates = false;
+    this.filterIgnoredPlatesEnabled = true;
     this.regexSearchEnabled = false;
 
     this.searchPlates();
@@ -164,5 +175,45 @@ export class PlatesComponent implements OnInit, OnDestroy, AfterViewInit {
       this.addingToIgnoreList = false;
       this.snackbarService.create(`${plateNumber} added to ignore list`, SnackBarType.Saved);
     });
+  }
+
+  public validateSearchPlateNumber() {
+    if (this.filterPlateNumber == '') {
+      this.filterPlateNumberIsValid = true;
+    }
+
+    if (this.regexSearchEnabled) {
+      try {
+        new RegExp(this.filterPlateNumber);
+        this.filterPlateNumberIsValid = true;
+      }
+      catch {
+        this.filterPlateNumberIsValid = false;
+      }
+    }
+    else {
+      this.filterPlateNumberIsValid = true;
+    }
+  }
+
+  public regexSearchToggled() {
+    if (this.regexSearchEnabled) {
+      this.filterStrictMatch = false;
+      this.filterStrictMatchEnabled = false;
+      this.filterIgnoredPlates = false;
+      this.filterIgnoredPlatesEnabled = false;
+    }
+    else {
+      this.filterStrictMatchEnabled = true;
+      this.filterIgnoredPlatesEnabled = true;
+    }
+    this.validateSearchPlateNumber();
+  }
+}
+
+export class MyErrorStateMatcher implements ErrorStateMatcher {
+  isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean {
+    const isSubmitted = form && form.submitted;
+    return !!(control && control.invalid && (control.dirty || control.touched || isSubmitted));
   }
 }

--- a/OpenAlprWebhookProcessor/LicensePlates/SearchLicensePlates/SearchLicensePlateHandler.cs
+++ b/OpenAlprWebhookProcessor/LicensePlates/SearchLicensePlates/SearchLicensePlateHandler.cs
@@ -33,6 +33,10 @@ namespace OpenAlprWebhookProcessor.LicensePlates.SearchLicensePlates
                 {
                     dbRequest = dbRequest.Where(x => x.BestNumber.Contains(request.PlateNumber));
                 }
+                else if (request.RegexSearchEnabled)
+                {
+                    dbRequest = dbRequest.Where(x => Regex.IsMatch(x.BestNumber, request.PlateNumber));
+                }
                 else
                 {
                     dbRequest = dbRequest.Where(x =>
@@ -70,11 +74,6 @@ namespace OpenAlprWebhookProcessor.LicensePlates.SearchLicensePlates
                             || !x.PossibleNumbers.Contains(plateToIgnore.PlateNumber));
                     }
                 }
-            }
-
-            if (request.RegexSearchEnabled)
-            {
-                dbRequest = dbRequest.Where(x => Regex.IsMatch(x.BestNumber, request.PlateNumber));
             }
 
             var totalCount = await dbRequest.CountAsync(cancellationToken);

--- a/OpenAlprWebhookProcessor/LicensePlates/SearchLicensePlates/SearchLicensePlateHandler.cs
+++ b/OpenAlprWebhookProcessor/LicensePlates/SearchLicensePlates/SearchLicensePlateHandler.cs
@@ -2,6 +2,7 @@
 using OpenAlprWebhookProcessor.Data;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -69,6 +70,11 @@ namespace OpenAlprWebhookProcessor.LicensePlates.SearchLicensePlates
                             || !x.PossibleNumbers.Contains(plateToIgnore.PlateNumber));
                     }
                 }
+            }
+
+            if (request.RegexSearchEnabled)
+            {
+                dbRequest = dbRequest.Where(x => Regex.IsMatch(x.BestNumber, request.PlateNumber));
             }
 
             var totalCount = await dbRequest.CountAsync(cancellationToken);

--- a/OpenAlprWebhookProcessor/LicensePlates/SearchLicensePlates/SearchLicensePlateRequest.cs
+++ b/OpenAlprWebhookProcessor/LicensePlates/SearchLicensePlates/SearchLicensePlateRequest.cs
@@ -14,6 +14,8 @@ namespace OpenAlprWebhookProcessor.LicensePlates.SearchLicensePlates
 
         public bool FilterIgnoredPlates { get; set; }
 
+        public bool RegexSearchEnabled { get; set; }
+
         public int PageNumber { get; set; }
 
         public int PageSize { get; set; }

--- a/OpenAlprWebhookProcessor/OpenAlprWebhookProcessor.csproj
+++ b/OpenAlprWebhookProcessor/OpenAlprWebhookProcessor.csproj
@@ -17,25 +17,25 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoMapper" Version="10.1.1" />
-		<PackageReference Include="Bogus" Version="32.1.1" />
-		<PackageReference Include="CoordinateSharp" Version="2.9.5.1" />
-		<PackageReference Include="Flurl" Version="3.0.1" />
-		<PackageReference Include="Hangfire" Version="1.7.19" />
-		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.19" />
+		<PackageReference Include="Bogus" Version="33.0.2" />
+		<PackageReference Include="CoordinateSharp" Version="2.10.2.2" />
+		<PackageReference Include="Flurl" Version="3.0.2" />
+		<PackageReference Include="Hangfire" Version="1.7.23" />
+		<PackageReference Include="Hangfire.AspNetCore" Version="1.7.23" />
 		<PackageReference Include="Hangfire.InMemory" Version="0.3.4" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.2" />
-		<PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="5.0.2" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.2">
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.6" />
+		<PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="5.0.6" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0-preview.4.21253.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.2" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0-preview.4.21253.1" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
-		<PackageReference Include="NUnit" Version="3.13.1" />
-		<PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
+		<PackageReference Include="NUnit" Version="3.13.2" />
+		<PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
 		<PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.0.1" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/OpenAlprWebhookProcessor/Users/UserService.cs
+++ b/OpenAlprWebhookProcessor/Users/UserService.cs
@@ -359,7 +359,7 @@ namespace OpenAlprWebhookProcessor.Users
             return true;
         }
 
-        private string GenerateJwtSecretKey(int keyLength)
+        private static string GenerateJwtSecretKey(int keyLength)
         {
             RNGCryptoServiceProvider rngCryptoServiceProvider = new RNGCryptoServiceProvider();
             byte[] randomBytes = new byte[keyLength];


### PR DESCRIPTION
ef core 6 adds native regex searching for sqlite. in my hometown police cruisers can be found searching `^(\d){5}$` for example, a plate with only 5 numbers on it.